### PR TITLE
Add undo/redo keyboard support

### DIFF
--- a/src/components/TableEditor.tsx
+++ b/src/components/TableEditor.tsx
@@ -59,11 +59,11 @@ function EditableCell({
   }) {
     const ref = useRef<HTMLTableCellElement>(null);
   
-    // Only sync when not focused so the caret doesn't jump
+    // Sync the DOM when value changes, but avoid useless writes that would move the caret
     useEffect(() => {
       const el = ref.current;
       if (!el) return;
-      if (document.activeElement !== el) el.textContent = value;
+      if (el.textContent !== value) el.textContent = value;
     }, [value]);
   
     return (
@@ -83,7 +83,7 @@ function EditableCell({
 
 
 export default function TableEditor() {
-    const { cards, upsertCards, clearAll } = useApp();
+    const { cards, upsertCards, clearAll, undo, redo } = useApp();
     const tbodyRef = useRef<HTMLTableSectionElement>(null);
     const fileRef = useRef<HTMLInputElement>(null);
 
@@ -116,6 +116,19 @@ export default function TableEditor() {
             const table = tr.parentElement as HTMLTableSectionElement;
             const rowIndex = Array.from(table.children).indexOf(tr);
             const colIndex = Array.from(tr.children).indexOf(td);
+
+            const lower = e.key.toLowerCase();
+            const ctrlOrMeta = e.ctrlKey || e.metaKey;
+            if (ctrlOrMeta && !e.shiftKey && lower === "z") {
+                e.preventDefault();
+                undo();
+                return;
+            }
+            if (ctrlOrMeta && (lower === "y" || (e.shiftKey && lower === "z"))) {
+                e.preventDefault();
+                redo();
+                return;
+            }
 
             if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
@@ -164,7 +177,7 @@ export default function TableEditor() {
             table.removeEventListener("input", onInput);
             table.removeEventListener("keydown", onKeydown as any);
         };
-    }, [upsertCards]);
+    }, [upsertCards, undo, redo]);
 
 
     function addEmptyRow(tb: HTMLTableSectionElement) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,8 @@ const PK = "fc-prefs-v1";
 
 export type AppState = {
     cards: Card[];
+    undoStack: Card[][];
+    redoStack: Card[][];
     view: "edit" | "review";
     order: Order;
     direction: Direction;
@@ -26,6 +28,8 @@ export type AppState = {
     setDirection: (d: Direction) => void;
     setDark: (b: boolean) => void;
     upsertCards: (cards: Card[]) => void;
+    undo: () => void;
+    redo: () => void;
     clearAll: () => void;
     startReview: () => void;
     next: () => void;
@@ -49,6 +53,8 @@ function loadPrefs(): Partial<Pick<AppState, "order" | "direction" | "dark">> {
 
 export const useApp = create<AppState>((set, get) => ({
     cards: [],
+    undoStack: [],
+    redoStack: [],
     view: "edit",
     order: loadPrefs().order || "chronological",
     direction: loadPrefs().direction || "term-first",
@@ -63,9 +69,9 @@ export const useApp = create<AppState>((set, get) => ({
     loadFromStorage: () => {
         try {
             const raw = JSON.parse(localStorage.getItem(SK) || "[]");
-            set({ cards: Array.isArray(raw) ? raw : [] });
+            set({ cards: Array.isArray(raw) ? raw : [], undoStack: [], redoStack: [] });
         } catch {
-            set({ cards: [] });
+            set({ cards: [], undoStack: [], redoStack: [] });
         }
     },
 
@@ -86,14 +92,50 @@ export const useApp = create<AppState>((set, get) => ({
     },
 
     upsertCards: (cards) => {
-        set({ cards });
+        set((state) => ({
+            cards,
+            undoStack: [...state.undoStack, state.cards],
+            redoStack: [],
+        }));
         // batch save
+        queueMicrotask(() => localStorage.setItem(SK, JSON.stringify(get().cards)));
+    },
+
+    undo: () => {
+        const { undoStack, cards, redoStack } = get();
+        if (undoStack.length === 0) return;
+        const prev = undoStack[undoStack.length - 1] as Card[];
+        set({
+            cards: prev,
+            undoStack: undoStack.slice(0, -1),
+            redoStack: [cards, ...redoStack],
+        });
+        queueMicrotask(() => localStorage.setItem(SK, JSON.stringify(get().cards)));
+    },
+
+    redo: () => {
+        const { redoStack, cards, undoStack } = get();
+        if (redoStack.length === 0) return;
+        const next = redoStack[0] as Card[];
+        set({
+            cards: next,
+            undoStack: [...undoStack, cards],
+            redoStack: redoStack.slice(1),
+        });
         queueMicrotask(() => localStorage.setItem(SK, JSON.stringify(get().cards)));
     },
 
     clearAll: () => {
         if (!confirm("Clear all cards?")) return;
-        set({ cards: [], learned: new Set(), orderList: [], idx: 0, flipped: false });
+        set((state) => ({
+            cards: [],
+            undoStack: [...state.undoStack, state.cards],
+            redoStack: [],
+            learned: new Set(),
+            orderList: [],
+            idx: 0,
+            flipped: false,
+        }));
         localStorage.setItem(SK, JSON.stringify([]));
     },
 


### PR DESCRIPTION
## Summary
- add undo/redo stacks in zustand store
- handle Ctrl+Z/Ctrl+Y in table editor to navigate history
- sync contenteditable cells without losing caret position

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68992000f50c8326ae8925d9815962c2